### PR TITLE
Fix boundary identification in getBody

### DIFF
--- a/decode/MailParser.php
+++ b/decode/MailParser.php
@@ -285,7 +285,7 @@ class MailParser
             $contentTypeRegex = '/^Content-Type: ?text\/plain/i';
         
         // there could be more than one boundary. This also skips the quotes if they are included.
-        \preg_match_all('/boundary=(?:|")([a-zA-Z0-9_=\.\(\)_\/+-]+)(?:|")(?:$|;)/mi', $this->raw, $matches);
+        \preg_match_all('/(*ANYCRLF)boundary=(?:|")([a-zA-Z0-9_=\.\(\)_\/+-]+)(?:|")(?:$|;)/mi', $this->raw, $matches);
         $boundaries = $matches[1];
         // sometimes boundaries are delimited by quotes - we want to remove them
         foreach ($boundaries as $i => $v) {
@@ -321,7 +321,7 @@ class MailParser
                 
                 // if the delimited is AAAAA, the line will be --AAAAA  - that's why we use substr
                 if (\is_array($boundaries)) {
-                    if (\in_array(\substr($line, 2), $boundaries)) {  // found the delimiter
+                    if (\in_array(\substr($line, 2), $boundaries) || \in_array(\substr($line, 2, -2), $boundaries)) {
                         break;
                     }
                 }


### PR DESCRIPTION
I was getting an issue where the current regex was failing to identify the boundary.
I traced this to the line breaks, the message I was parsing used CRLF, where as I believe preg_match_all was only checking for LF.
The additional CR between the " and the LF meant the boundary wasn't identified.

I've added (*ANYCRLF) which has sorted this.

Also the last line of the messages I was parsing contained the boundary surrounded by -- (not just preceded by it). This was causing the boundary to be considered part of the HTML body.
I've added in the option to check for this.